### PR TITLE
Added /etc/passwd username caching (9s->0.2s exec time @tacc). Kent

### DIFF
--- a/README
+++ b/README
@@ -6,6 +6,13 @@ Texas Advanced Computing Center
 Originally: November 2012
 karl@tacc.utexas.edu
 
+Modified: April, 2020 Include    cache_etcpwd_unames=1
+          in showq.conf file to use /etc/passwd username caching.
+          @TACC this reduced 9s execution time down to 0.2s.
+          milfeld@tacc.utexas.edu (Kent Milfeld in the wild:)
+
+TODO: More documentation is needed for showq.conf file. Kent
+
 -------------------
 Build Instructions:
 -------------------

--- a/main.cpp
+++ b/main.cpp
@@ -33,6 +33,9 @@ int main(int argc, char **argv)
   Slurm_Showq sq;
 
   sq.parse_supported_options(argc,argv);
+
+  sq.get_etcpwd_unames();  // uses cache if cache_etcpwd_unames flag is true
+
   sq.query_running_jobs();
 
   sq.check_maintenance();

--- a/slurm_showq.h
+++ b/slurm_showq.h
@@ -46,6 +46,9 @@ using namespace std;
 #include <cstdlib>
 #include <vector>
 
+#include <map>
+#include <sstream>
+
 #define VERSION 1.0
 
 class Slurm_Showq {
@@ -55,6 +58,10 @@ class Slurm_Showq {
   void query_running_jobs();
   void parse_supported_options(int argc, char *argv[]);
   void check_maintenance();
+
+  void get_etcpwd_unames ();
+
+  bool  cache_etcpwd_unames;
 
 private:
 
@@ -76,6 +83,9 @@ private:
   bool  show_all_reserv;
   bool  show_utilization;
   float RES_LEAD_WINDOW;
+
+//bool  cache_etcpwd_unames;
+  map   <int,string> uid_uname;
 
   std::string progname;		 // binary name for stdout
   int total_avail_nodes;	 // max # of nodes (for utilization calculations)


### PR DESCRIPTION
/etc/passwd username caching was added.  This is about 40x faster, and needed when there are a lot of jobs on the system (e.g. at TACC it reduced time from 9 sec. to 0.2 sec.)

This is a pull against the master.  I turned off printing statements left in the master, shown here.
(Merger should make sure everything else matches the production, as was done previously to
eliminate this print statement.) Verification should be performed on code. 
Please make sure shows.conf has "cache_etcpwd_unames=1" at TACC.

```C++
  if(showq_conf)
        {
     // printf("The following showq configuration file is used:\n%s\n",showq_conf);
        read_runtime_config(showq_conf, false);  //use TACC customized showq_conf
        }
  else
        {
     // printf("No additional configuration file is found.\nThe system default one is used.\n");
        read_runtime_config("/usr/local/bin/showq.conf", false); //use the system showq_conf 
        }
```